### PR TITLE
FIX: do not lose/kill sticky windows when changing layouts.

### DIFF
--- a/layout_manager.sh
+++ b/layout_manager.sh
@@ -127,7 +127,9 @@ if [[ "$ACTION" = "LOAD LAYOUT" ]]; then
 
   # delete all empty layout windows from the workspace
   for (( i=0 ; $a-20 ; a=$a+1 )); do
-    i3-msg "focus parent, kill" > $LOG_FILE 2>&1
+    if [ $(xprop -id $(xdotool getactivewindow) | grep -q _NET_WM_STATE_STICKY) -eq 0 ]; then
+      i3-msg "focus parent, kill" > $LOG_FILE 2>&1
+    fi
   done
 
   # then we can apply to chosen layout


### PR DESCRIPTION
Previous behaviour caused sticky windows to get killed when deleting layouts before applying a layout and then reintroducing windows.  i3 supports sticky windows (they're great).  With this change, when we iterate through layouts (to kill) we check if a the selected window is _NET_WM_STATE_STICKY.  If so, then will not kill.