### PR TITLE
feat: Make compliant with XDG dir spec

### DIFF
--- a/layout_manager.sh
+++ b/layout_manager.sh
@@ -49,7 +49,11 @@ fi
 # #}
 
 if [ -z "$XDG_CONFIG_HOME" ]; then
-  LAYOUT_PATH=~/.layouts
+  if [ -e "${HOME}/.layouts" ] && [ -n "$(command ls -A ${HOME}/.layouts)" ]; then
+    LAYOUT_PATH=${HOME}/.layouts
+  else
+    LAYOUT_PATH="${HOME}/.config/i3-layout-manager/layouts"
+  fi
 else
   LAYOUT_PATH="$XDG_CONFIG_HOME/i3-layout-manager/layouts"
 fi
@@ -265,7 +269,8 @@ MATCH ANY" | rofi -i -dmenu -p "How to identify windows? (xprop style)")
   # all-tree file we can find the workspace part.
 
   # remove the floating window part, that would screw up out matching
-  $VIM_BIN $HEADLESS -nEs -c '%g/"floating_con"/norm ?{nd%' -c "wqa" -- "$LAYOUT_FILE"
+  $VIM_BIN $HEADLESS -nEs -c '%g/"floating_con"/norm ?{
+nd%' -c "wqa" -- "$LAYOUT_FILE"
 
   # remove comments
   $VIM_BIN $HEADLESS -nEs -c '%g/\/\//norm dd' -c "wqa" -- "$LAYOUT_FILE"
@@ -337,7 +342,8 @@ MATCH ANY" | rofi -i -dmenu -p "How to identify windows? (xprop style)")
   # the information about the split type
   cat $ALL_WS_FILE | cat - $LAYOUT_FILE > /tmp/tmp.txt && mv /tmp/tmp.txt $LAYOUT_FILE
   # add closing bracked at the end
-  $VIM_BIN $HEADLESS -nEs -c 'normal Go]}' -c "wqa" -- "$LAYOUT_FILE"
+  $VIM_BIN $HEADLESS -nEs -c 'normal Go]
+}' -c "wqa" -- "$LAYOUT_FILE"
 
   # now we have to do some postprocessing on it, all is even advices on the official website
   # https://i3wm.org/docs/layout-saving.html
@@ -390,19 +396,23 @@ MATCH ANY" | rofi -i -dmenu -p "How to identify windows? (xprop style)")
   $VIM_BIN $HEADLESS -nEs -c '%g/\/\//norm dd' -c "wqa" -- "$LAYOUT_FILE"
 
   # add a missing comma to the last element of array we just deleted
-  $VIM_BIN $HEADLESS -nEs -c '%g/swallows/norm j^%k:s/,$//g' -c "wqa" -- "$LAYOUT_FILE"
+  $VIM_BIN $HEADLESS -nEs -c '%g/swallows/norm j^%k:s/,$//g
+' -c "wqa" -- "$LAYOUT_FILE"
 
   # delete all empty lines
   $VIM_BIN $HEADLESS -nEs -c '%g/^$/norm dd' -c "wqa" -- "$LAYOUT_FILE"
 
   # pick up floating containers and move them out of the root container
-  $VIM_BIN $HEADLESS -nEs -c '%g/floating_con/norm ?{nd%GAp' -c "wqa" -- "$LAYOUT_FILE"
+  $VIM_BIN $HEADLESS -nEs -c '%g/floating_con/norm ?{
+nd%GA
+p' -c "wqa" -- "$LAYOUT_FILE"
 
   # delete all empty lines
   $VIM_BIN $HEADLESS -nEs -c '%g/^$/norm dd' -c "wqa" -- "$LAYOUT_FILE"
 
   # add missing commas between the newly created inner parts of the root element
-  $VIM_BIN $HEADLESS -nEs -c '%s/}\n{/},{/g' -c "wqa" -- "$LAYOUT_FILE"
+  $VIM_BIN $HEADLESS -nEs -c '%s/}\n{/},
+{/g' -c "wqa" -- "$LAYOUT_FILE"
 
   # surroun everythin in []
   $VIM_BIN $HEADLESS -nEs -c 'normal ggO[Go]' -c "wqa" -- "$LAYOUT_FILE"


### PR DESCRIPTION
If `XDG_CONFIG_HOME` is not set:
 -  And `.layouts` is already populated, then continue to use it.
 - Otherwise use `${HOME}/i3-layout-manager/layouts` instead

Resolves #26

Also, not sure why it's saying all the `^M` thing is changing. I just edited the script through github's website.